### PR TITLE
Make squeak-history loadable on CI

### DIFF
--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/baseline..st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/baseline..st
@@ -1,4 +1,4 @@
-as yet unclassified
+baseline
 baseline: spec
 	"Squeak 5.2 and above."
 	<baseline>

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/checkSista.st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/checkSista.st
@@ -1,4 +1,4 @@
-as yet unclassified
+scripts
 checkSista
 
 	(Smalltalk classNamed: #EncoderForSistaV1)

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/isCI.st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/isCI.st
@@ -1,0 +1,6 @@
+private
+isCI
+
+	^ (Smalltalk classNamed: #SmalltalkCI)
+		ifNil: [false]
+		ifNotNil: [:sci | (sci perform: #getEnv: with: #CI) = #true]

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/loadData.st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/loadData.st
@@ -1,6 +1,8 @@
 scripts
 loadData
 
+	self isCI ifTrue: [^ self].
+	
 	#(
 		(10 'Setting archive path')
 		(20 'Downloading mailman archives')
@@ -11,18 +13,18 @@ loadData
 	) do: [:spec | spec first caseOf: {
 		[10] -> [SqhMailmanAggregator archivePath].
 		[20] -> [SqhMailmanAggregator downloadAllLists].
-		[30] -> [self
-			recommend: 'Do you want to try downloading the Tweak list\archives from web.archive.org?\\If this fails, try looking for the data at\github.com/hpi-swa/squeak-history.' withCRs
-			title: 'Squeak History - Preparation'
-			ifAccepted: [SqhMailmanAggregator downloadTweak]].
+		[30] -> [(UIManager default
+			confirm: 'Do you want to try downloading the Tweak list\archives from web.archive.org?\\If this fails, try looking for the data at\github.com/hpi-swa/squeak-history.' withCRs
+			title: 'Squeak History - Preparation')
+				ifTrue: [SqhMailmanAggregator downloadTweak]].
 		[40] -> [SqhMailmanAggregator newDefault
 			showProgress: true;
 			deriveRulesForAuthorKeyNormalization].
 		[50] -> [SqhMailmanAggregator newDefault
 			showProgress: true;
 			resetCacheForMailMessages].
-		[99] -> [self
-			recommend: 'Preparation finished.\\Do you want to count the number of\messages as an example query?' withCRs
-			title: 'Squeak History - Example'
-			ifAccepted: [SqhMailmanAggregator newDefault countMessagesPerList explore]].
+		[99] -> [(UIManager default
+			confirm: 'Preparation finished.\\Do you want to count the number of\messages as an example query?' withCRs
+			title: 'Squeak History - Example')
+				ifTrue: [SqhMailmanAggregator newDefault countMessagesPerList explore]].
 	}] displayingProgress: [:spec | spec second, '...'].

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/loadData.st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/loadData.st
@@ -1,4 +1,4 @@
-as yet unclassified
+scripts
 loadData
 
 	#(
@@ -11,18 +11,18 @@ loadData
 	) do: [:spec | spec first caseOf: {
 		[10] -> [SqhMailmanAggregator archivePath].
 		[20] -> [SqhMailmanAggregator downloadAllLists].
-		[30] -> [(UIManager default
-			confirm: 'Do you want to try downloading the Tweak list\archives from web.archive.org?\\If this fails, try looking for the data at\github.com/hpi-swa/squeak-history.' withCRs
-			title: 'Squeak History - Preparation')
-				ifTrue: [SqhMailmanAggregator downloadTweak]].
+		[30] -> [self
+			recommend: 'Do you want to try downloading the Tweak list\archives from web.archive.org?\\If this fails, try looking for the data at\github.com/hpi-swa/squeak-history.' withCRs
+			title: 'Squeak History - Preparation'
+			ifAccepted: [SqhMailmanAggregator downloadTweak]].
 		[40] -> [SqhMailmanAggregator newDefault
 			showProgress: true;
 			deriveRulesForAuthorKeyNormalization].
 		[50] -> [SqhMailmanAggregator newDefault
 			showProgress: true;
 			resetCacheForMailMessages].
-		[99] -> [(UIManager default
-			confirm: 'Preparation finished.\\Do you want to count the number of\messages as an example query?' withCRs
-			title: 'Squeak History - Example')
-				ifTrue: [SqhMailmanAggregator newDefault countMessagesPerList explore]].
+		[99] -> [self
+			recommend: 'Preparation finished.\\Do you want to count the number of\messages as an example query?' withCRs
+			title: 'Squeak History - Example'
+			ifAccepted: [SqhMailmanAggregator newDefault countMessagesPerList explore]].
 	}] displayingProgress: [:spec | spec second, '...'].

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/recommend.title.ifAccepted..st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/recommend.title.ifAccepted..st
@@ -1,0 +1,7 @@
+private
+recommend: queryString title: titleString ifAccepted: aBlock
+
+	self isCI ifTrue: [^ nil].
+	
+	(Project uiManager confirm: queryString title: titleString) ifFalse: [^ nil].
+	^ aBlock value

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/recommend.title.ifAccepted..st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/recommend.title.ifAccepted..st
@@ -1,7 +1,0 @@
-private
-recommend: queryString title: titleString ifAccepted: aBlock
-
-	self isCI ifTrue: [^ nil].
-	
-	(Project uiManager confirm: queryString title: titleString) ifFalse: [^ nil].
-	^ aBlock value

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/methodProperties.json
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/methodProperties.json
@@ -5,5 +5,4 @@
 		"baseline:" : "mt 3/26/2019 15:45",
 		"checkSista" : "mt 3/26/2019 15:46",
 		"isCI" : "ct 5/18/2021 13:47",
-		"loadData" : "ct 5/18/2021 13:48",
-		"recommend:title:ifAccepted:" : "ct 5/18/2021 13:47" } }
+		"loadData" : "ct 5/18/2021 14:04" } }

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/methodProperties.json
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/methodProperties.json
@@ -4,4 +4,6 @@
 	"instance" : {
 		"baseline:" : "mt 3/26/2019 15:45",
 		"checkSista" : "mt 3/26/2019 15:46",
-		"loadData" : "mt 3/26/2019 15:25" } }
+		"isCI" : "ct 5/18/2021 13:47",
+		"loadData" : "ct 5/18/2021 13:48",
+		"recommend:title:ifAccepted:" : "ct 5/18/2021 13:47" } }

--- a/packages/SqueakHistory.package/SqhMailmanAggregator.class/instance/messagesNormalizedDo..st
+++ b/packages/SqueakHistory.package/SqhMailmanAggregator.class/instance/messagesNormalizedDo..st
@@ -1,18 +1,16 @@
 enumerating - raw
 messagesNormalizedDo: workBlock
 	"Normalizes the content of each messages before evaluating the workBlock."
-	
-	self rulesForAuthorKeyNormalizationDerived
-		ifEmpty: [Warning signal: 'The author-key normalization is limited. Please run #deriveRulesForAuthorKeyNormalization.
-			
-If you are doing this right now, please ignore this warning.'].
+
+	self rulesForAuthorKeyNormalizationDerived ifEmpty: [
+		(thisContext findContextSuchThat: [:ctx | ctx selector = #deriveRulesForAuthorKeyNormalization]) ifNil: [
+			self notify: 'The author-key normalization is limited. Please run #deriveRulesForAuthorKeyNormalization.']].
 	
 	self messagesDo: [:mailMessage :listName |
-		
 		self normalizeDateAndTime: mailMessage.
 		self normalizeMailAddress: mailMessage.
 		
 		self normalizeAuthor: mailMessage.
 		self lookupAuthorInitials: mailMessage.
 		
-		workBlock cull: mailMessage cull: listName].
+		workBlock cull: mailMessage cull: listName]

--- a/packages/SqueakHistory.package/SqhMailmanAggregator.class/methodProperties.json
+++ b/packages/SqueakHistory.package/SqhMailmanAggregator.class/methodProperties.json
@@ -68,7 +68,7 @@
 		"messagesCachedDo:" : "mt 3/27/2019 10:31",
 		"messagesCollect:" : "mt 3/22/2019 16:02",
 		"messagesDo:" : "mt 3/26/2019 10:54",
-		"messagesNormalizedDo:" : "mt 2/10/2019 13:18",
+		"messagesNormalizedDo:" : "ct 5/18/2021 14:39",
 		"messagesSelect:" : "mt 2/8/2019 19:23",
 		"normalizeAuthor:" : "mt 3/26/2019 11:10",
 		"normalizeDateAndTime:" : "mt 2/11/2019 09:59",


### PR DESCRIPTION
Make squeak-history loadable on CI by skipping optional `#loadData` if active SmalltalkCI is detected.

Required for SqueakInboxTalk. Fixes #4.