### PR TITLE
Clean up dangling file streams

### DIFF
--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/class/on..st
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/class/on..st
@@ -1,4 +1,4 @@
-as yet unclassified
+instance creation
 on: aStream
 
 	^ self new on: aStream

--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/class/onFileNamed..st
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/class/onFileNamed..st
@@ -1,4 +1,4 @@
-as yet unclassified
+instance creation
 onFileNamed: fileName
 
 	^ self on: (StandardFileStream readOnlyFileNamed: fileName)

--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/class/onFileNamed.do..st
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/class/onFileNamed.do..st
@@ -1,0 +1,6 @@
+instance creation
+onFileNamed: fileName do: aBlock
+
+	^ StandardFileStream
+		readOnlyFileNamed: fileName
+		do: [:stream | aBlock value: (self on: stream)]

--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/instance/close.st
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/instance/close.st
@@ -1,0 +1,4 @@
+initialize-release
+close
+
+	self stream close

--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/instance/fileName.st
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/instance/fileName.st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing
 fileName
 
 	^ stream fullName

--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/instance/on..st
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/instance/on..st
@@ -1,4 +1,4 @@
-as yet unclassified
+initialize-release
 on: aStream
 
 	stream := aStream.

--- a/packages/SqueakHistory.package/SqhMBoxReadWriter.class/methodProperties.json
+++ b/packages/SqueakHistory.package/SqhMBoxReadWriter.class/methodProperties.json
@@ -1,10 +1,12 @@
 {
 	"class" : {
 		"on:" : "mt 2/5/2019 15:26",
-		"onFileNamed:" : "mt 2/5/2019 17:52" },
+		"onFileNamed:" : "mt 2/5/2019 17:52",
+		"onFileNamed:do:" : "ct 5/20/2021 21:35" },
 	"instance" : {
 		"allMessages" : "mt 2/7/2019 17:19",
 		"atEnd" : "mt 2/7/2019 17:19",
+		"close" : "ct 5/20/2021 21:34",
 		"fileName" : "mt 3/22/2019 15:16",
 		"getChunkFrom:to:" : "mt 3/22/2019 14:59",
 		"getMessageFrom:to:" : "mt 3/22/2019 15:48",

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/class/cleanUp.st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/class/cleanUp.st
@@ -1,0 +1,4 @@
+initialize-release
+cleanUp
+
+	self closeAllStreams.

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/class/closeAllStreams.st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/class/closeAllStreams.st
@@ -1,0 +1,7 @@
+initialize-release
+closeAllStreams
+	"self closeAllStreams"
+
+	ArchiveFileStreams ifNil: [^ self].
+	ArchiveFileStreams reject: [:stream | stream closed] thenDo: [:stream | stream close].
+	ArchiveFileStreams := nil

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/class/from..st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/class/from..st
@@ -1,4 +1,4 @@
-as yet unclassified
+instance creation
 from: mailMessage
 
 	^ self new

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/instance/bodyText.st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/instance/bodyText.st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing - domain
 bodyText
 
 	^ self

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/instance/isInReplyToValid.st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/instance/isInReplyToValid.st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing - domain
 isInReplyToValid
 	"See SqhMailmanAggregator >> #resetCacheForMailConversations."
 	

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/instance/printOn..st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/instance/printOn..st
@@ -1,4 +1,4 @@
-as yet unclassified
+printing
 printOn: stream
 
 	stream

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/instance/setMailMessage.during..st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/instance/setMailMessage.during..st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing - raw
 setMailMessage: mm during: workBlock
 	mailMessage := mm.
 	[workBlock cull: self]

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/instance/subject.st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/instance/subject.st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing - domain
 subject
 
 	^ self

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/instance/subjectFeatures.st
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/instance/subjectFeatures.st
@@ -1,4 +1,4 @@
-as yet unclassified
+accessing - domain
 subjectFeatures
 
 	^ self

--- a/packages/SqueakHistory.package/SqhMailWrapper.class/methodProperties.json
+++ b/packages/SqueakHistory.package/SqhMailWrapper.class/methodProperties.json
@@ -1,5 +1,7 @@
 {
 	"class" : {
+		"cleanUp" : "ct 5/25/2021 21:52",
+		"closeAllStreams" : "ct 5/25/2021 21:06",
 		"from:" : "mt 3/22/2019 15:31" },
 	"instance" : {
 		"assureProperties" : "mt 3/22/2019 15:50",

--- a/packages/SqueakHistory.package/SqhMailmanAggregator.class/instance/messagesDo..st
+++ b/packages/SqueakHistory.package/SqhMailmanAggregator.class/instance/messagesDo..st
@@ -1,14 +1,14 @@
 enumerating - raw
 messagesDo: workBlock
 
-	| directory reader |
+	| directory |
 	self with: self mailingLists do: [:listName |
 		directory := FileDirectory on: self class archivePath, FileDirectory slash, listName.
 		directory assureExistence. "Necessary?"
 		directory fileEntries do: [:fileEntry |
-			reader := SqhMBoxReadWriter onFileNamed: fileEntry fullName.
-			[reader atEnd] whileFalse: [
-				reader nextMessage in: [:mailMessage |
-					self logOnTranscript ifTrue: [Transcript showln: mailMessage subject].
-					mailMessage fields at: 'squeak-file-name' put: reader fileName.
-					workBlock cull: mailMessage cull: listName]]]].
+			SqhMBoxReadWriter onFileNamed: fileEntry fullName do: [:reader |
+				[reader atEnd] whileFalse: [
+					reader nextMessage in: [:mailMessage |
+						self logOnTranscript ifTrue: [Transcript showln: mailMessage subject].
+						mailMessage fields at: 'squeak-file-name' put: reader fileName.
+						workBlock cull: mailMessage cull: listName]]]]].

--- a/packages/SqueakHistory.package/SqhMailmanAggregator.class/methodProperties.json
+++ b/packages/SqueakHistory.package/SqhMailmanAggregator.class/methodProperties.json
@@ -67,7 +67,7 @@
 		"messageRegularLinesDo:" : "mt 3/22/2019 14:21",
 		"messagesCachedDo:" : "mt 3/27/2019 10:31",
 		"messagesCollect:" : "mt 3/22/2019 16:02",
-		"messagesDo:" : "mt 3/26/2019 10:54",
+		"messagesDo:" : "ct 5/25/2021 21:51",
 		"messagesNormalizedDo:" : "ct 5/18/2021 14:39",
 		"messagesSelect:" : "mt 2/8/2019 19:23",
 		"normalizeAuthor:" : "mt 3/26/2019 11:10",


### PR DESCRIPTION
In the past, one could not manually edit the archive directory on your machine after running the aggregator scripts. This was caused by dangling file streams that were never closed by SqueakHistory. This change makes it possible to close them again manually, and automatically closes them in an aggregator usage scenario where the file streams were never reused again. Apart from that, the general file-stream-pooling solution is not restricted.

- Add protocol on `SqhMBoxReadWriter` for closing streams
- Use it in `SqhMailmanAggregator >> #messagesDo:`
- Add clean-up protocol on `SqhMailWrapper`