### PR TITLE
Add compatibility with V3PlusClosures bytecode set

### DIFF
--- a/packages/BaselineOfSqueakHistory.package/.squot-contents
+++ b/packages/BaselineOfSqueakHistory.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ '70490c5a669dd640881abbf7b7e17ecb' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/baseline..st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/baseline..st
@@ -5,7 +5,5 @@ baseline: spec
 	
 	spec for: #common do: [
 		spec package: 'SqueakHistory' with: [
-			spec
-				preLoadDoIt: #checkSista;
-				postLoadDoIt: #loadData].
+			spec postLoadDoIt: #loadData].
 		spec group: 'default' with: #('SqueakHistory')].

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/checkSista.st
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/instance/checkSista.st
@@ -1,8 +1,0 @@
-scripts
-checkSista
-
-	(Smalltalk classNamed: #EncoderForSistaV1)
-		ifNil: [Warning signal: 'This environment does not support the SistaV1 Bytecode Set! Method loading might fail if proceeded.' withCRs]
-		ifNotNil: [:sistaBytecodeSet |
-			CompiledCode preferredBytecodeSetEncoderClass ~~ sistaBytecodeSet ifTrue: [
-				Warning signal: 'The support for the SistaV1 Bytecode Set needs to be activated. Make sure to use the correct VM, too. Until then, method loading might fail if proceeded.']].

--- a/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/methodProperties.json
+++ b/packages/BaselineOfSqueakHistory.package/BaselineOfSqueakHistory.class/methodProperties.json
@@ -2,7 +2,6 @@
 	"class" : {
 		 },
 	"instance" : {
-		"baseline:" : "mt 3/26/2019 15:45",
-		"checkSista" : "mt 3/26/2019 15:46",
+		"baseline:" : "ct 10/16/2022 01:22",
 		"isCI" : "ct 5/18/2021 13:47",
 		"loadData" : "ct 5/18/2021 14:04" } }

--- a/packages/SqueakHistory.package/.squot-contents
+++ b/packages/SqueakHistory.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ '3d052dfc6372e64b9e4f15b3281f81f1' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/SqueakHistory.package/SqhMailmanAggregator.class/instance/rulesForAuthorKeyClarification.st
+++ b/packages/SqueakHistory.package/SqhMailmanAggregator.class/instance/rulesForAuthorKeyClarification.st
@@ -2,151 +2,151 @@ normalization - support
 rulesForAuthorKeyClarification
 	"Use the mail address to expand short user names to clarify and correct their author key."
 
-	^ rulesForAuthorKeyClarification ifNil: [rulesForAuthorKeyClarification := Dictionary newFrom: {
-		'lars.wassermann@googlemail.com' -> ('lars' -> 'larswassermann').
-		'lars@cymfony.com' -> ('lars' -> 'larsnilsson').
-	
-		'alberto@chiaroscuro.com' -> ('alberto' -> 'albertoberti').
-		'andrew@beta4.com' -> ('andrew' -> 'andrewcatton').
+	^ rulesForAuthorKeyClarification ifNil: [rulesForAuthorKeyClarification := Dictionary newFrom:
+		(#(('lars.wassermann@googlemail.com' 'lars' 'larswassermann')
+		('lars@cymfony.com' 'lars' 'larsnilsson')
 		
-		'a.kuckartz@lilly.ping.de' -> ('akuckartz' -> 'andreaskuckartz').
+		('alberto@chiaroscuro.com' 'alberto' 'albertoberti')
+		('andrew@beta4.com' 'andrew' 'andrewcatton')
 		
-		'bert@freudenbergs.de' -> ('bert' -> 'vanessafreudenberg').
-		'bert@isg.cs.uni-magdeburg.de' -> ('bert' -> 'vanessafreudenberg').
-		'squeakland-forum@squeakland.org' -> ('bert' -> 'vanessafreudenberg').
-		'etoys-dev-forum@squeakland.org' -> ('bert' -> 'vanessafreudenberg').
+		('a.kuckartz@lilly.ping.de' 'akuckartz' 'andreaskuckartz')
 		
-		'tim@io.com' -> ('tim' -> 'timolson').
-		'tim@nada1.de' -> ('tim' -> 'timfelgentreff').
-		'tim@rowledge.org' -> ('tim' -> 'timrowledge').
-		'tim@sumeru.stanford.edu' -> ('tim' -> 'timrowledge').
-		'tyguy11@mindspring.com' -> ('tim' -> 'timwill').
+		('bert@freudenbergs.de' 'bert' 'vanessafreudenberg')
+		('bert@isg.cs.uni-magdeburg.de' 'bert' 'vanessafreudenberg')
+		('squeakland-forum@squeakland.org' 'bert' 'vanessafreudenberg')
+		('etoys-dev-forum@squeakland.org' 'bert' 'vanessafreudenberg')
 		
-		'squeak414@free.fr' -> (#('squeak' 'stan') -> 'stanshepherd').
-		'squeak@vanrooijen.com' -> ('squeak' -> 'petervanrooijen').
-		'squeak1@continentalbrno.cz' -> ('squeak' -> 'pavelkrivanek').
+		('tim@io.com' 'tim' 'timolson')
+		('tim@nada1.de' 'tim' 'timfelgentreff')
+		('tim@rowledge.org' 'tim' 'timrowledge')
+		('tim@sumeru.stanford.edu' 'tim' 'timrowledge')
+		('tyguy11@mindspring.com' 'tim' 'timwill')
 		
-		'ducasse@iam.unibe.ch' -> (#('sd' 'andrewblackvia') -> 'stephaneducasse').
+		('squeak414@free.fr' ('squeak' 'stan') 'stanshepherd')
+		('squeak@vanrooijen.com' 'squeak' 'petervanrooijen')
+		('squeak1@continentalbrno.cz' 'squeak' 'pavelkrivanek')
 		
-		'chris.schreiner@online.no' -> ('chris' -> 'chrispatrickschreiner').
-		'chris@chrisburkert.de' -> ('chris' -> 'chrisburkert').
-		'chris@funkyobjects.org' -> ('chris' -> 'chrismuller').
-		'cunningham.cb@gmail.com' -> ('chris' -> 'chriscunningham').
-		'intern_boy_chris@yahoo.com' -> ('chris' -> 'satelliteboy'). "???"
+		('ducasse@iam.unibe.ch' ('sd' 'andrewblackvia') 'stephaneducasse')
 		
-		'casey_damess@cox.net' -> ('casey' -> 'caseydamess').
-		'catgame@gmail.com' -> ('cg' -> 'catgame'). "???"
-		'cg@tric.nl' -> ('cg' -> 'ceesdegroot').
-		'cg@cdegroot.com' -> ('cg' -> 'ceesdegroot').
+		('chris.schreiner@online.no' 'chris' 'chrispatrickschreiner')
+		('chris@chrisburkert.de' 'chris' 'chrisburkert')
+		('chris@funkyobjects.org' 'chris' 'chrismuller')
+		('cunningham.cb@gmail.com' 'chris' 'chriscunningham')
+		('intern_boy_chris@yahoo.com' 'chris' 'satelliteboy') "???"
 		
-		'dnorton@mindspring.com' -> ('dan' -> 'dannorton'). "???"
-		'mr.d.poon@gmail.com' -> ('dan' -> 'danielpoon').
+		('casey_damess@cox.net' 'casey' 'caseydamess')
+		('catgame@gmail.com' 'cg' 'catgame') "???"
+		('cg@tric.nl' 'cg' 'ceesdegroot')
+		('cg@cdegroot.com' 'cg' 'ceesdegroot')
+		
+		('dnorton@mindspring.com' 'dan' 'dannorton') "???"
+		('mr.d.poon@gmail.com' 'dan' 'danielpoon')
 
-		'aikidave@gmail.com' -> ('dave' -> 'akidave'). "???"
-		'dave@bedarra.com' -> ('dave' -> 'davethomasbedarra').
-		'dave_and_laura_lowry@mac.com' -> ('dave' -> 'davelowry').
+		('aikidave@gmail.com' 'dave' 'akidave') "???"
+		('dave@bedarra.com' 'dave' 'davethomasbedarra')
+		('dave_and_laura_lowry@mac.com' 'dave' 'davelowry')
 		
-		'david@myth.sdsu.edu' -> ('david' -> 'davidsalamon').
-		'deanmao@cc.gatech.edu' -> ('dino' -> 'deanpumao').
+		('david@myth.sdsu.edu' 'david' 'davidsalamon')
+		('deanmao@cc.gatech.edu' 'dino' 'deanpumao')
 		
-		'eliot@parcplace.com' -> ('eliot' -> 'eliotmiranda').
+		('eliot@parcplace.com' 'eliot' 'eliotmiranda')
 		
-		'frank@angband.za.org' -> ('frank' -> 'frankshearar').
-		'frank@canyon-medical.com' -> ('frank' -> 'franksergeant').
-		'frank@crystal-objects.com' -> ('frank' -> 'frankcaggiano').
+		('frank@angband.za.org' 'frank' 'frankshearar')
+		('frank@canyon-medical.com' 'frank' 'franksergeant')
+		('frank@crystal-objects.com' 'frank' 'frankcaggiano')
 		
-		'grit@impara.de' ->('grit' -> 'gritschuster').
-		'goran@krampe.se' -> ('goran' -> 'goerankrampe').
+		('grit@impara.de' 'grit' 'gritschuster')
+		('goran@krampe.se' 'goran' 'goerankrampe')
 		
-		'henrik@ekenberg.org' -> ('henrik' -> 'henrikekenberg').
-		'hh2@lexdb.net' -> ('hh' -> 'hanneshirzel').
+		('henrik@ekenberg.org' 'henrik' 'henrikekenberg')
+		('hh2@lexdb.net' 'hh' 'hanneshirzel')
 		
-		'jp1660@att.net' -> ('john' -> 'johnpfersich').
-		'wiljo@mac.com' -> ('john' -> 'johnsarkela').
-		'jason.johnson.081@gmail.com' -> ('jj' -> 'jasonjohnson').
-		'jj@objectsroot.com' -> ('jj' -> 'giovannigiorgi'). "Ha! Ha!"
+		('jp1660@att.net' 'john' 'johnpfersich')
+		('wiljo@mac.com' 'john' 'johnsarkela')
+		('jason.johnson.081@gmail.com' 'jj' 'jasonjohnson')
+		('jj@objectsroot.com' 'jj' 'giovannigiorgi') "Ha! Ha!"
 		
-		'keith_hodges@yahoo.co.uk' -> ('keith' -> 'keithhodges').
-		'keithy@consultant.com' -> ('keith' -> 'keithhodges').
+		('keith_hodges@yahoo.co.uk' 'keith' 'keithhodges')
+		('keithy@consultant.com' 'keith' 'keithhodges')
 		
-		'leo@smalltalking.net' -> ('leo' -> 'leodemarco').
-		'lex@lnx-1.theinternetone.net' -> ('lex' -> 'lexspoon').
-		'lex@cc.gatech.edu' -> ('lex' -> 'lexspoon').
+		('leo@smalltalking.net' 'leo' 'leodemarco')
+		('lex@lnx-1.theinternetone.net' 'lex' 'lexspoon')
+		('lex@cc.gatech.edu' 'lex' 'lexspoon')
 		
-		'demonfoxkyubi@gmail.com' -> ('max' -> 'demonfoxkyubi'). "???"
+		('demonfoxkyubi@gmail.com' 'max' 'demonfoxkyubi') "???"
 		
-		'marcel@metaobject.com' -> ('marcel' -> 'marcelweiher').
-		'marcus@ira.uka.de' -> ('marcus' -> 'marcusdenker').
+		('marcel@metaobject.com' 'marcel' 'marcelweiher')
+		('marcus@ira.uka.de' 'marcus' 'marcusdenker')
 		
-		'mail@marco-paga.de' -> ('mail' -> 'marcopaga').
-		'mailinglist.fischer@bluewin.ch' -> ('mailinglist' -> 'alainfischer').
+		('mail@marco-paga.de' 'mail' 'marcopaga')
+		('mailinglist.fischer@bluewin.ch' 'mailinglist' 'alainfischer')
 		
-		'michal-list@auf.net' -> ('michal' -> 'michalstarke').
-		'miso.fastlist@auf.net' -> ('michal' -> 'michalstarke'). "???"
+		('michal-list@auf.net' 'michal' 'michalstarke')
+		('miso.fastlist@auf.net' 'michal' 'michalstarke') "???"
 		
-		'ned@bike-nomad.com' -> ('ned' -> 'nedkonz').
-		'ned@squeakland.org' -> ('ned' -> 'nedkonz').
+		('ned@bike-nomad.com' 'ned' 'nedkonz')
+		('ned@squeakland.org' 'ned' 'nedkonz')
 		
-		'petton.nicolas@gmail.com' -> ('nico' -> 'nicolaspetton').
-		'nperigoi@etu.info.unicaen.fr' -> ('nico' -> 'nperigoi'). "???"
+		('petton.nicolas@gmail.com' 'nico' 'nicolaspetton')
+		('nperigoi@etu.info.unicaen.fr' 'nico' 'nperigoi') "???"
 		
-		'ok@cs.otago.ac.nz' -> ('ok' -> 'richardaokeefe').
+		('ok@cs.otago.ac.nz' 'ok' 'richardaokeefe')
 		
-		'shouse.patrick@gmail.com' -> ('patrick' -> 'patrickshouse').
-		'pbpublist@gmail.com' -> ('phil' -> 'philb'). " Phil B is not Philippe Back "
+		('shouse.patrick@gmail.com' 'patrick' 'patrickshouse')
+		('pbpublist@gmail.com' 'phil' 'philb') " Phil B is not Philippe Back "
 		
-		'ret@deltanet.com' -> ('rick' -> 'rickthomas').
-		'cubsno1@gmail.com' -> ('rick' -> 'rickhedin').
-		'ricardosbc@netwave.com.br' -> ('rick' -> 'ricardosbc').
+		('ret@deltanet.com' 'rick' 'rickthomas')
+		('cubsno1@gmail.com' 'rick' 'rickhedin')
+		('ricardosbc@netwave.com.br' 'rick' 'ricardosbc')
 		
-		'ritametzger@prodigy.net' -> ('rita' -> 'ritametzger').
-		'rita@isg.cs.uni-magdeburg.de' -> ('rita' -> 'ritafreudenberg').
-		'ritafreudenberg@googlemail.com' -> ('rita' -> 'ritafreudenberg').
+		('ritametzger@prodigy.net' 'rita' 'ritametzger')
+		('rita@isg.cs.uni-magdeburg.de' 'rita' 'ritafreudenberg')
+		('ritafreudenberg@googlemail.com' 'rita' 'ritafreudenberg')
 		
-		'r.a.lamb@att.net' -> ('robert' -> 'robertlamb').
-		'robert.w.withers@gmail.com' -> ('robert' -> 'robertwithers').
-		'charlie.robbats@gmail.com' -> ('charlierobbats' -> 'robertwithers').
+		('r.a.lamb@att.net' 'robert' 'robertlamb')
+		('robert.w.withers@gmail.com' 'robert' 'robertwithers')
+		('charlie.robbats@gmail.com' 'charlierobbats' 'robertwithers')
 		
-		'kusasa@shuttleworthfoundation.org' -> ('sam' -> 'samchristie').
-		'sam@rfc1149.net' -> ('sam' -> 'samueltardieu').
+		('kusasa@shuttleworthfoundation.org' 'sam' 'samchristie')
+		('sam@rfc1149.net' 'sam' 'samueltardieu')
 		
-		's@xss.de' -> ('s' -> 'stefanschmiedl'). "???"
+		('s@xss.de' 's' 'stefanschmiedl') "???"
 		
-		'sergio@village-buzz.com' -> ('sergio' -> 'sergioruiz').
-		'sergiolist@village-buzz.com' -> ('sergio' -> 'sergioruiz').
+		('sergio@village-buzz.com' 'sergio' 'sergioruiz')
+		('sergiolist@village-buzz.com' 'sergio' 'sergioruiz')
 		
-		'stan@stanheckman.com' -> ('stan' -> 'stanheckman').
-		'stephan@stack.nl' -> ('stephan' -> 'stephaneggermont').
+		('stan@stanheckman.com' 'stan' 'stanheckman')
+		('stephan@stack.nl' 'stephan' 'stephaneggermont')
 		
-		'sdw2@shineonline.co.nz' -> ('stephen' -> 'stephenwoolerton').
-		'stephen@pairhome.net' -> ('stephen' -> 'stephenpair').
-		's_rowley@hotmail.com' -> ('stephen' -> 'stephenrowley'). "???"
+		('sdw2@shineonline.co.nz' 'stephen' 'stephenwoolerton')
+		('stephen@pairhome.net' 'stephen' 'stephenpair')
+		('s_rowley@hotmail.com' 'stephen' 'stephenrowley') "???"
 		
-		'steve@daviesfam.org' -> ('steve' -> 'stephendavies').
-		'steve@swerlingphoto.com' -> ('steve' -> 'stevenswerling').
-		'sjg2001@mac.com' -> ('steve' -> 'stevegutierrez').
+		('steve@daviesfam.org' 'steve' 'stephendavies')
+		('steve@swerlingphoto.com' 'steve' 'stevenswerling')
+		('sjg2001@mac.com' 'steve' 'stevegutierrez')
 		
-		'sven@dcs.uconn.edu' -> ('sven' -> 'svencrouse').
+		('sven@dcs.uconn.edu' 'sven' 'svencrouse')
 		
-		'squeak@groucho.it' -> ('squeak' -> 'chobin'). "???"
-		'info@groucho.it' -> ('groucho' -> 'chobin'). "???"
+		('squeak@groucho.it' 'squeak' 'chobin') "???"
+		('info@groucho.it' 'groucho' 'chobin') "???"
 		
-		'squeak@lisp-reader.hungry.com' -> ('squeak' -> 'lispreaderhungry'). "???"
-		'squeak@ursine.com' -> ('squeak' -> 'michaelbryan'). 
-		'squeak@oafamily.com' -> ('squeak' -> 'danielabeshouse'). 
-		'squeak@sysa.barnett.sk' -> ('squeak' -> 'janbarger').
-		'squeak@ekenberg.org' -> ('squeak' -> 'henrikekenberg').
-		'squeak@bike-nomad.com' -> ('squeak' -> 'nedkonz').
-		'squeak@techscribe.com' -> ('squeak' -> 'joseph').
+		('squeak@lisp-reader.hungry.com' 'squeak' 'lispreaderhungry') "???"
+		('squeak@ursine.com' 'squeak' 'michaelbryan') 
+		('squeak@oafamily.com' 'squeak' 'danielabeshouse') 
+		('squeak@sysa.barnett.sk' 'squeak' 'janbarger')
+		('squeak@ekenberg.org' 'squeak' 'henrikekenberg')
+		('squeak@bike-nomad.com' 'squeak' 'nedkonz')
+		('squeak@techscribe.com' 'squeak' 'joseph')
 		
-		'squeak@ajr.e4ward.com' -> ('squeak' -> 'alanreider').
-		'ajr@e4ward.com' -> ('ajr' -> 'alanreider').
-		'gmane-x9y9abu9r8@ajr.e4ward.com' -> ('ajr' -> 'alanreider').
-		'squeakdev@reider.net' -> ('squeakdev' -> 'alanreider').
-		'squeakdev1@reider.net' -> ('squeakdev1' -> 'alanreider').
-		'ly4aegw02@sneakemail.com' -> ('ajr' -> 'alanreider'). "!!!"
-"		'sstnjpm02@sneakemail.com' ??? alanreider ???"
+		('squeak@ajr.e4ward.com' 'squeak' 'alanreider')
+		('ajr@e4ward.com' 'ajr' 'alanreider')
+		('gmane-x9y9abu9r8@ajr.e4ward.com' 'ajr' 'alanreider')
+		('squeakdev@reider.net' 'squeakdev' 'alanreider')
+		('squeakdev1@reider.net' 'squeakdev1' 'alanreider')
+		('ly4aegw02@sneakemail.com' 'ajr' 'alanreider') "!!!"
+"		('sstnjpm02@sneakemail.com' ??? alanreider ???"
 		
-		'das.linux@gmx.de' -> ('tobias' -> 'tobiaspape').
-		'thom@indiana.edu' -> ('thom' -> 'thomkevingillespie').
-	}]
+		('das.linux@gmx.de' 'tobias' 'tobiaspape')
+		('thom@indiana.edu' 'thom' 'thomkevingillespie'))
+			 collect: [:ea | ea first -> (ea second -> ea third)])]

--- a/packages/SqueakHistory.package/SqhMailmanAggregator.class/methodProperties.json
+++ b/packages/SqueakHistory.package/SqhMailmanAggregator.class/methodProperties.json
@@ -77,7 +77,7 @@
 		"resetCacheForMailConversations" : "mt 10/29/2020 16:27:18.765282",
 		"resetCacheForMailMessages" : "mt 10/27/2020 13:12:31.91446",
 		"rulesForAuthorFullNameClarification" : "mt 11/26/2020 09:27:25.051346",
-		"rulesForAuthorKeyClarification" : "mt 10/22/2020 10:40:15.574332",
+		"rulesForAuthorKeyClarification" : "ct 10/16/2022 01:18",
 		"rulesForAuthorKeyNormalization" : "mt 10/27/2020 13:28:57.30846",
 		"rulesForAuthorKeyNormalizationDerived" : "mt 2/10/2019 13:17",
 		"rulesForLetterNormalization" : "mt 2/7/2019 18:33",


### PR DESCRIPTION
Make it possible to encode the package using the old bytecode set by rewriting #rulesForAuthorKeyClarification which had too many literals for the old bytecode set to use a single literal. Remove sista check in the baseline.

Closes https://github.com/hpi-swa-lab/squeak-inbox-talk/issues/60.